### PR TITLE
chore: add doc script aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,19 +60,19 @@ npm install
 ### 开发服务器
 
 ```bash
-npm run dev
+npm run dev # 或 npm run docs:dev
 ```
 
 ### 构建生产版本
 
 ```bash
-npm run build
+npm run build # 或 npm run docs:build
 ```
 
 ### 预览构建结果
 
 ```bash
-npm run preview
+npm run preview # 或 npm run docs:preview
 ```
 
 ## 🚀 部署

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Node.js全栈开发学习指南 - 从零基础到高级水平的完整学习路径",
   "main": "index.js",
   "scripts": {
+    "dev": "npm run docs:dev",
+    "build": "npm run docs:build",
+    "preview": "npm run docs:preview",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",


### PR DESCRIPTION
## Summary
- add dev/build/preview scripts as aliases for docs commands
- document docs script aliases in README

## Testing
- `npm test` (fails: Missing script "test")
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b957c894a48327b4026a859e79c04e